### PR TITLE
chore: 개발 환경 세팅(카카오 지도 포트 번호 8080 지정)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,6 @@ import react from "@vitejs/plugin-react-swc";
 import tsconfigPaths from "vite-tsconfig-paths";
 import tailwindcss from "tailwindcss";
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     react(),
@@ -11,5 +10,8 @@ export default defineConfig({
     //@ts-ignore
     tailwindcss(),
   ],
+  server: {
+    port: 8080,  // 서버 포트를 8080으로 설정
+    strictPort: true,
+  },
 });
-// 플러그인에 tailwindcss()을 내용을 추가해줍니다


### PR DESCRIPTION
## 📢 기능 설명
: 카카오 지도 연결 포트 번호 8080 설정
(다른 포트 번호를 사용하고 싶다면 해당 파일 코드에서 서버 관련 코드를 지워주세요^^)

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 Issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{이슈넘버}
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
